### PR TITLE
RET-1852: ET1 serving- Who are you sending this document to

### DIFF
--- a/definitions/json/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField.json
@@ -4148,12 +4148,6 @@
   {
     "CaseTypeId": "ET_Scotland",
     "CaseFieldID": "servingDocumentRecipient",
-    "UserRole": "citizen",
-    "CRUD": "CRUD"
-  },
-  {
-    "CaseTypeId": "ET_Scotland",
-    "CaseFieldID": "servingDocumentRecipient",
     "UserRole": "caseworker-employment-etjudge-scotland",
     "CRUD": "CRUD"
   },

--- a/definitions/json/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField.json
@@ -4106,7 +4106,7 @@
   {
     "CaseTypeId": "ET_Scotland",
     "CaseFieldID": "servingDocumentCollection",
-    "UserRole": "caseworker-employment-englandwales",
+    "UserRole": "caseworker-employment-etjudge-scotland",
     "CRUD": "CRUD"
   },
   {
@@ -4118,7 +4118,7 @@
   {
     "CaseTypeId": "ET_Scotland",
     "CaseFieldID": "servingDocumentCollection",
-    "UserRole": "caseworker-employment-etjudge-englandwales",
+    "UserRole": "caseworker-employment-etjudge-scotland",
     "CRUD": "CRUD"
   },
   {
@@ -4148,7 +4148,7 @@
   {
     "CaseTypeId": "ET_Scotland",
     "CaseFieldID": "servingDocumentRecipient",
-    "UserRole": "caseworker-employment-englandwales",
+    "UserRole": "caseworker-employment-etjudge-scotland",
     "CRUD": "CRUD"
   },
   {
@@ -4160,7 +4160,7 @@
   {
     "CaseTypeId": "ET_Scotland",
     "CaseFieldID": "servingDocumentRecipient",
-    "UserRole": "caseworker-employment-etjudge-englandwales",
+    "UserRole": "caseworker-employment-etjudge-scotland",
     "CRUD": "CRUD"
   },
   {

--- a/definitions/json/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField.json
@@ -4148,7 +4148,7 @@
   {
     "CaseTypeId": "ET_Scotland",
     "CaseFieldID": "servingDocumentRecipient",
-    "UserRole": "caseworker-employment-etjudge-scotland",
+    "UserRole": "caseworker-employment-scotland",
     "CRUD": "CRUD"
   },
   {

--- a/definitions/json/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField.json
@@ -1454,7 +1454,7 @@
   {
     "CaseTypeId": "ET_Scotland",
     "CaseFieldID": "claimantHearingPreference",
-    "UserRole": "caseworker-employment-englandwales",
+    "UserRole": "caseworker-employment-scotland",
     "CRUD": "CRU"
   },
   {
@@ -1466,7 +1466,7 @@
   {
     "CaseTypeId": "ET_Scotland",
     "CaseFieldID": "claimantHearingPreference",
-    "UserRole": "caseworker-employment-etjudge-englandwales",
+    "UserRole": "caseworker-employment-etjudge-scotland",
     "CRUD": "CRU"
   },
   {
@@ -4106,6 +4106,12 @@
   {
     "CaseTypeId": "ET_Scotland",
     "CaseFieldID": "servingDocumentCollection",
+    "UserRole": "caseworker-employment-scotland",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_Scotland",
+    "CaseFieldID": "servingDocumentCollection",
     "UserRole": "caseworker-employment-etjudge-scotland",
     "CRUD": "CRUD"
   },
@@ -4113,12 +4119,6 @@
     "CaseTypeId": "ET_Scotland",
     "CaseFieldID": "servingDocumentCollection",
     "UserRole": "citizen",
-    "CRUD": "CRUD"
-  },
-  {
-    "CaseTypeId": "ET_Scotland",
-    "CaseFieldID": "servingDocumentCollection",
-    "UserRole": "caseworker-employment-etjudge-scotland",
     "CRUD": "CRUD"
   },
   {

--- a/definitions/json/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField.json
@@ -4118,12 +4118,6 @@
   {
     "CaseTypeId": "ET_Scotland",
     "CaseFieldID": "servingDocumentCollection",
-    "UserRole": "citizen",
-    "CRUD": "CRUD"
-  },
-  {
-    "CaseTypeId": "ET_Scotland",
-    "CaseFieldID": "servingDocumentCollection",
     "UserRole": "caseworker-employment-api",
     "CRUD": "CRUD"
   },

--- a/definitions/json/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField.json
@@ -4128,6 +4128,48 @@
     "CRUD": "CRUD"
   },
   {
+    "CaseTypeId": "ET_Scotland",
+    "CaseFieldID": "otherTypeDocumentName",
+    "UserRole": "caseworker-employment",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeId": "ET_Scotland",
+    "CaseFieldID": "servingDocumentRecipient",
+    "UserRole": "caseworker-employment",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeId": "ET_Scotland",
+    "CaseFieldID": "servingDocumentRecipient",
+    "UserRole": "caseworker-employment-etjudge",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeId": "ET_Scotland",
+    "CaseFieldID": "servingDocumentRecipient",
+    "UserRole": "caseworker-employment-englandwales",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_Scotland",
+    "CaseFieldID": "servingDocumentRecipient",
+    "UserRole": "citizen",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_Scotland",
+    "CaseFieldID": "servingDocumentRecipient",
+    "UserRole": "caseworker-employment-etjudge-englandwales",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_Scotland",
+    "CaseFieldID": "servingDocumentRecipient",
+    "UserRole": "caseworker-employment-api",
+    "CRUD": "CRUD"
+  },
+  {
     "CaseTypeId": "ET_Scotland_Listings",
     "CaseFieldID": "listingDate",
     "UserRole": "caseworker-employment-scotland",

--- a/definitions/json/CaseEventToFields.json
+++ b/definitions/json/CaseEventToFields.json
@@ -2289,7 +2289,64 @@
     "PageDisplayOrder": 1,
     "PageFieldDisplayOrder": 1,
     "ShowSummaryChangeOption": "Y",
+    "CallBackURLMidEvent": "${ET_COS_URL}/midServingDocumentOtherTypeNames",
     "PageLabel": "Upload documents",
+    "PageColumnNumber": 1
+  },
+  {
+    "CaseTypeID": "ET_Scotland",
+    "CaseEventID": "uploadDocumentForServing",
+    "CaseFieldID": "horizontalLine",
+    "DisplayContext": "READONLY",
+    "PageID": 2,
+    "PageDisplayOrder": 2,
+    "PageFieldDisplayOrder": 1,
+    "ShowSummaryChangeOption": "Y",
+    "PageLabel": "Who are you sending this document to?",
+    "PageShowCondition": "otherTypeDocumentName != \"\"",
+    "PageColumnNumber": 1
+  },
+  {
+    "CaseTypeID": "ET_Scotland",
+    "CaseEventID": "uploadDocumentForServing",
+    "CaseFieldID": "otherTypeDocumentName",
+    "DisplayContext": "MANDATORY",
+    "FieldShowCondition": "horizontalLine=\"dummy\"",
+    "PageID": 2,
+    "PageDisplayOrder": 2,
+    "PageFieldDisplayOrder": 2,
+    "PageColumnNumber": 1
+  },
+  {
+    "CaseTypeID": "ET_Scotland",
+    "CaseEventID": "uploadDocumentForServing",
+    "CaseFieldID": "otherTypeDocumentNameLabel",
+    "DisplayContext": "READONLY",
+    "PageID": 2,
+    "PageDisplayOrder": 2,
+    "PageFieldDisplayOrder": 3,
+    "PageColumnNumber": 1
+  },
+  {
+    "CaseTypeID": "ET_Scotland",
+    "CaseEventID": "uploadDocumentForServing",
+    "CaseFieldID": "selectAllThatApply",
+    "DisplayContext": "READONLY",
+    "PageID": 2,
+    "PageDisplayOrder": 2,
+    "PageFieldDisplayOrder": 4,
+    "ShowSummaryChangeOption": "Y",
+    "PageColumnNumber": 1
+  },
+  {
+    "CaseTypeID": "ET_Scotland",
+    "CaseEventID": "uploadDocumentForServing",
+    "CaseFieldID": "servingDocumentRecipient",
+    "DisplayContext": "MANDATORY",
+    "PageID": 2,
+    "PageDisplayOrder": 2,
+    "PageFieldDisplayOrder": 5,
+    "ShowSummaryChangeOption": "Y",
     "PageColumnNumber": 1
   },
   {

--- a/definitions/json/CaseField.json
+++ b/definitions/json/CaseField.json
@@ -1,6 +1,13 @@
 [
   {
     "CaseTypeID": "ET_Scotland",
+    "ID": "horizontalLine",
+    "Label": "<hr>",
+    "FieldType": "Label",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "ET_Scotland",
     "ID": "tribunalCorrespondenceAddress",
     "Label": "Correspondence Address",
     "FieldType": "AddressUK",
@@ -849,6 +856,35 @@
     "Label": "Upload document PDF",
     "FieldType": "Collection",
     "FieldTypeParameter": "ServingDocumentUpload",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "ET_Scotland",
+    "ID": "selectAllThatApply",
+    "Label": "Select all that apply.",
+    "FieldType": "Label",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "ET_Scotland",
+    "ID": "servingDocumentRecipient",
+    "Label": " ",
+    "FieldType": "MultiSelectList",
+    "FieldTypeParameter": "fl_ServingDocumentRecipient",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "ET_Scotland",
+    "ID": "otherTypeDocumentName",
+    "Label": "Serving document other type name placeholder",
+    "FieldType": "Text",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "ET_Scotland",
+    "ID": "otherTypeDocumentNameLabel",
+    "Label": "${otherTypeDocumentName}",
+    "FieldType": "Label",
     "SecurityClassification": "Public"
   },
   {

--- a/definitions/json/Scotland Scrubbed.json
+++ b/definitions/json/Scotland Scrubbed.json
@@ -4209,5 +4209,24 @@
     "ListElementCode": "Another type of document",
     "ListElement": "Another type of document",
     "DisplayOrder": 25
+  },
+  {
+    "ID": "fl_ServingDocumentRecipient",
+    "ListElementCode": "Acas",
+    "ListElement": "Acas",
+    "DisplayOrder": 1
+  },
+  {
+    "ID": "fl_ServingDocumentRecipient",
+    "ListElementCode": "Claimant",
+    "ListElement": "Claimant",
+    "DisplayOrder": 2
+  },
+  {
+    "ID": "fl_ServingDocumentRecipient",
+    "ListElementCode": "Respondent",
+    "ListElement": "Respondent",
+    "DisplayOrder": 3
   }
+
 ]


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RET-1852


### Change description ###
Following the submission of the ET1 form by the Claimant, the ET1 is vetted, and if accepted then the ET1 is required to be served to the Respondent (as per the Respondent details in the ET1 form).  A notification letter of ET1 serving is sent to the Respondent, together with a copy of ET3 form (by post) ** 

NB: This page will only come up if on the Upload letters page dropdown, the user selects another type of document which is not a known standard letter. Once the document has been uploaded, the admin/caseworker will need to select who the document will be sent to.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
