### PR TITLE
Maintanence for ET3 Vetting

### DIFF
--- a/definitions/json/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField.json
@@ -9163,31 +9163,31 @@
   },
   {
     "CaseTypeId": "ET_Scotland",
-    "CaseFieldID": "et3GeneralNotesRespondentAddressMatch",
+    "CaseFieldID": "et3GeneralNotesAddressMatch",
     "UserRole": "caseworker-employment-etjudge",
     "CRUD": "R"
   },
   {
     "CaseTypeId": "ET_Scotland",
-    "CaseFieldID": "et3GeneralNotesRespondentAddressMatch",
+    "CaseFieldID": "et3GeneralNotesAddressMatch",
     "UserRole": "caseworker-employment-etjudge-scotland",
     "CRUD": "CRUD"
   },
   {
     "CaseTypeId": "ET_Scotland",
-    "CaseFieldID": "et3GeneralNotesRespondentAddressMatch",
+    "CaseFieldID": "et3GeneralNotesAddressMatch",
     "UserRole": "caseworker-employment-scotland",
     "CRUD": "CRUD"
   },
   {
     "CaseTypeId": "ET_Scotland",
-    "CaseFieldID": "et3GeneralNotesRespondentAddressMatch",
+    "CaseFieldID": "et3GeneralNotesAddressMatch",
     "UserRole": "caseworker-employment",
     "CRUD": "R"
   },
   {
     "CaseTypeId": "ET_Scotland",
-    "CaseFieldID": "et3GeneralNotesRespondentAddressMatch",
+    "CaseFieldID": "et3GeneralNotesAddressMatch",
     "UserRole": "caseworker-employment-api",
     "CRUD": "CRUD"
   },

--- a/definitions/json/CaseEventToFields.json
+++ b/definitions/json/CaseEventToFields.json
@@ -4663,7 +4663,7 @@
   {
     "CaseTypeID": "ET_Scotland",
     "CaseEventID": "et3Vetting",
-    "CaseFieldID": "et3GeneralNotesRespondentAddressMatch",
+    "CaseFieldID": "et3GeneralNotesAddressMatch",
     "DisplayContext": "OPTIONAL",
     "PageID": 11,
     "PageDisplayOrder": 11,

--- a/definitions/json/CaseField.json
+++ b/definitions/json/CaseField.json
@@ -2244,7 +2244,7 @@
   },
   {
     "CaseTypeID": "ET_Scotland",
-    "ID": "et3GeneralNotesRespondentAddressMatch",
+    "ID": "et3GeneralNotesAddressMatch",
     "Label": "General notes",
     "FieldType": "TextArea",
     "SecurityClassification": "Public"

--- a/definitions/json/ComplexTypes.json
+++ b/definitions/json/ComplexTypes.json
@@ -591,6 +591,22 @@
   },
   {
     "ID": "ET3Vetting",
+    "ListElementCode": "et3DoWeHaveRespondentsName",
+    "FieldType": "YesOrNo",
+    "ElementLabel": "Do we have the respondent's name?",
+    "SecurityClassification": "Public",
+    "FieldShowCondition": "et3DoWeHaveRespondentsName!=\"\""
+  },
+  {
+    "ID": "ET3Vetting",
+    "ListElementCode": "et3GeneralNotesRespondentName",
+    "FieldType": "TextArea",
+    "ElementLabel": "General notes",
+    "SecurityClassification": "Public",
+    "FieldShowCondition": "et3GeneralNotesRespondentName!=\"\""
+  },
+  {
+    "ID": "ET3Vetting",
     "ListElementCode": "et3DoesRespondentsNameMatch",
     "FieldType": "YesOrNo",
     "ElementLabel": "Does the respondent's name match?",
@@ -615,6 +631,22 @@
   },
   {
     "ID": "ET3Vetting",
+    "ListElementCode": "et3DoWeHaveRespondentsAddress",
+    "FieldType": "YesOrNo",
+    "ElementLabel": "Do we have the respondent's address?",
+    "SecurityClassification": "Public",
+    "FieldShowCondition": "et3DoWeHaveRespondentsAddress!=\"\""
+  },
+  {
+    "ID": "ET3Vetting",
+    "ListElementCode": "et3GeneralNotesRespondentAddress",
+    "FieldType": "TextArea",
+    "ElementLabel": "General notes",
+    "SecurityClassification": "Public",
+    "FieldShowCondition": "et3GeneralNotesRespondentAddress!=\"\""
+  },
+  {
+    "ID": "ET3Vetting",
     "ListElementCode": "et3DoesRespondentsAddressMatch",
     "FieldType": "YesOrNo",
     "ElementLabel": "Does the respondent's address match?",
@@ -631,11 +663,11 @@
   },
   {
     "ID": "ET3Vetting",
-    "ListElementCode": "et3GeneralNotesRespondentAddress",
+    "ListElementCode": "et3GeneralNotesAddressMatch",
     "FieldType": "TextArea",
     "ElementLabel": "General notes",
     "SecurityClassification": "Public",
-    "FieldShowCondition": "et3GeneralNotesRespondentAddress!=\"\""
+    "FieldShowCondition": "et3GeneralNotesAddressMatch!=\"\""
   },
   {
     "ID": "ET3Vetting",
@@ -660,6 +692,15 @@
     "ElementLabel": "General notes",
     "SecurityClassification": "Public",
     "FieldShowCondition": "et3GeneralNotesCaseListed!=\"\""
+  },
+  {
+    "ID": "ET3Vetting",
+    "ListElementCode": "et3IsThisLocationCorrect",
+    "FieldType": "FixedRadioList",
+    "ElementLabel": "Is this location correct?",
+    "SecurityClassification": "Public",
+    "FieldShowCondition": "et3IsThisLocationCorrect!=\"\"",
+    "FieldTypeParameter": "fl_et3_tribunal_location_change"
   },
   {
     "ID": "ET3Vetting",
@@ -814,47 +855,6 @@
     "ElementLabel": "Additional information",
     "SecurityClassification": "Public",
     "FieldShowCondition": "et3AdditionalInformation!=\"\""
-  },
-  {
-    "ID": "ET3Vetting",
-    "ListElementCode": "et3NameAddressRespondent",
-    "FieldType": "Text",
-    "ElementLabel": "et3NameAddressRespondent",
-    "SecurityClassification": "Public",
-    "FieldShowCondition": "et3IsThereAnEt3Response=\"dummy\""
-  },
-  {
-    "ID": "ET3Vetting",
-    "ListElementCode": "et3DoWeHaveRespondentsName",
-    "FieldType": "YesOrNo",
-    "ElementLabel": "et3DoWeHaveRespondentsName",
-    "SecurityClassification": "Public",
-    "FieldShowCondition": "et3IsThereAnEt3Response=\"dummy\""
-  },
-  {
-    "ID": "ET3Vetting",
-    "ListElementCode": "et3IsThisLocationCorrect",
-    "FieldType": "FixedRadioList",
-    "ElementLabel": "et3IsThisLocationCorrect",
-    "SecurityClassification": "Public",
-    "FieldShowCondition": "et3IsThereAnEt3Response=\"dummy\"",
-    "FieldTypeParameter": "fl_et3_tribunal_location_change"
-  },
-  {
-    "ID": "ET3Vetting",
-    "ListElementCode": "et3GeneralNotesRespondentName",
-    "FieldType": "TextArea",
-    "ElementLabel": "et3GeneralNotesRespondentName",
-    "SecurityClassification": "Public",
-    "FieldShowCondition": "et3IsThereAnEt3Response=\"dummy\""
-  },
-  {
-    "ID": "ET3Vetting",
-    "ListElementCode": "et3DoWeHaveRespondentsAddress",
-    "FieldType": "YesOrNo",
-    "ElementLabel": "et3DoWeHaveRespondentsAddress",
-    "SecurityClassification": "Public",
-    "FieldShowCondition": "et3IsThereAnEt3Response=\"dummy\""
   },
   {
     "ID": "ET3Vetting",


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Maintanence for ET3 Vetting:

+ Group et3 fields together
+ Fix bug where general notes on the address mismatch page didn't save due to a too long field name

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
