### PR TITLE
Et3 response save documents

### DIFF
--- a/definitions/json/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField.json
@@ -2197,6 +2197,36 @@
   },
   {
     "CaseTypeId": "ET_Scotland",
+    "CaseFieldID": "et3ResponseDocumentCollection",
+    "UserRole": "caseworker-employment",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeId": "ET_Scotland",
+    "CaseFieldID": "et3ResponseDocumentCollection",
+    "UserRole": "caseworker-employment-etjudge",
+    "CRUD": "R"
+  },
+  {
+    "CaseTypeId": "ET_Scotland",
+    "CaseFieldID": "et3ResponseDocumentCollection",
+    "UserRole": "caseworker-employment-scotland",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_Scotland",
+    "CaseFieldID": "et3ResponseDocumentCollection",
+    "UserRole": "caseworker-employment-etjudge-scotland",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_Scotland",
+    "CaseFieldID": "et3ResponseDocumentCollection",
+    "UserRole": "caseworker-employment-api",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_Scotland",
     "CaseFieldID": "restrictedReporting",
     "UserRole": "caseworker-employment",
     "CRUD": "R"

--- a/definitions/json/CaseEvent.json
+++ b/definitions/json/CaseEvent.json
@@ -81,7 +81,7 @@
     "ShowEventNotes": "N",
     "ShowSummary": "Y",
     "CallBackURLAboutToStartEvent": "${ET_COS_URL}/et3Response/aboutToStart",
-    "CallBackURLAboutToSubmitEvent": "",
+    "CallBackURLAboutToSubmitEvent": "${ET_COS_URL}/et3Response/aboutToSubmit",
     "CallBackURLSubmittedEvent": "${ET_COS_URL}/et3Response/processingComplete",
     "EventEnablingCondition": ""
   },

--- a/definitions/json/CaseField.json
+++ b/definitions/json/CaseField.json
@@ -211,6 +211,15 @@
   },
   {
     "CaseTypeID": "ET_Scotland",
+    "ID": "et3ResponseDocumentCollection",
+    "Label": "ET3 response documentation",
+    "HintText": "Upload documentation for the case",
+    "FieldType": "Collection",
+    "FieldTypeParameter": "DocumentUpload",
+    "SecurityClassification": "Public"
+  },
+  {
+    "CaseTypeID": "ET_Scotland",
     "ID": "additionalCaseInfo",
     "Label": "Additional information",
     "HintText": "Additional case information",

--- a/definitions/json/CaseField.json
+++ b/definitions/json/CaseField.json
@@ -3031,7 +3031,7 @@
     "ID": "et3ResponseContestClaimDocument",
     "Label": "Upload a document to your response",
     "FieldType": "Collection",
-    "FieldTypeParameter": "Document",
+    "FieldTypeParameter": "DocumentUpload",
     "SecurityClassification": "Public"
   },
   {

--- a/definitions/json/CaseTypeTab.json
+++ b/definitions/json/CaseTypeTab.json
@@ -1136,6 +1136,15 @@
   {
     "CaseTypeID": "ET_Scotland",
     "Channel": "CaseWorker",
+    "TabID": "CaseDocuments",
+    "TabLabel": "Documents",
+    "TabDisplayOrder": 14,
+    "CaseFieldID": "et3ResponseDocumentCollection",
+    "TabFieldDisplayOrder": 1
+  },
+  {
+    "CaseTypeID": "ET_Scotland",
+    "Channel": "CaseWorker",
     "TabID": "CaseHistory",
     "TabLabel": "History",
     "TabDisplayOrder": 15,


### PR DESCRIPTION
### Change description ###
Added function to save the documents submitted in the ET3 Response form onto the document tab


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
