### PR TITLE
fixes Rule 28 Notice claimant to response and respondent

### DIFF
--- a/definitions/json/ComplexTypes.json
+++ b/definitions/json/ComplexTypes.json
@@ -5616,7 +5616,7 @@
     "ID": "etInitialConsiderationRule28",
     "ListElementCode": "etICRule28ClaimToBe",
     "FieldType": "FixedRadioList",
-    "ElementLabel": "Claim to be",
+    "ElementLabel": "Response to be",
     "FieldTypeParameter": "frl_etICRule28ClaimToBe",
     "SecurityClassification": "Public",
     "RetainHiddenValue": "No"
@@ -5641,7 +5641,7 @@
   {
     "ID": "etInitialConsiderationRule28",
     "ListElementCode": "etICRule28NumberOfDays",
-    "ElementLabel": "Number of days for claimant to provide written representations",
+    "ElementLabel": "Number of days for respondent to provide written representations",
     "FieldType": "Number",
     "SecurityClassification": "Public",
     "RetainHiddenValue": "No"

--- a/definitions/json/EventToComplexTypes.json
+++ b/definitions/json/EventToComplexTypes.json
@@ -5950,7 +5950,7 @@
     "CaseEventID": "initialConsideration",
     "CaseFieldID": "etInitialConsiderationRule28",
     "ListElementCode": "etICRule28ClaimToBe",
-    "EventElementLabel": "Claim to be",
+    "EventElementLabel": "Response to be",
     "FieldDisplayOrder": 1,
     "DisplayContext": "MANDATORY"
   },
@@ -5977,7 +5977,7 @@
     "CaseEventID": "initialConsideration",
     "CaseFieldID": "etInitialConsiderationRule28",
     "ListElementCode": "etICRule28NumberOfDays",
-    "EventElementLabel": "Number of days for claimant to provide written representations",
+    "EventElementLabel": "Number of days for respondent to provide written representations",
     "FieldDisplayOrder": 4,
     "DisplayContext": "MANDATORY"
   }


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-2209

### Change description ###
Changed Rule 26 claim to be to response to be and Number of days for claimant to respondent


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
