### PR TITLE
removed superfluous et3ResponseDocument field

### DIFF
--- a/definitions/json/CaseField.json
+++ b/definitions/json/CaseField.json
@@ -3109,14 +3109,6 @@
   },
   {
     "CaseTypeID": "ET_Scotland",
-    "ID": "et3ResponseDocument",
-    "Label": " ",
-    "FieldType": "Document",
-    "FieldTypeParameter": "DocumentUpload",
-    "SecurityClassification": "Public"
-  },
-  {
-    "CaseTypeID": "ET_Scotland",
     "ID": "et3NotificationDocCollection",
     "Label": "Upload document PDF",
     "FieldType": "Collection",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-2411

### Change description ###

Removed et3ResponseDocument field as we're storing et3 response documents in documentCollection now

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
