### PR TITLE
RET-2530. Don't store links of hublinks, only their statuses.

### DIFF
--- a/definitions/json/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField.json
@@ -19639,37 +19639,37 @@
   },
   {
     "CaseTypeId": "ET_Scotland",
-    "CaseFieldID": "hubLinks",
+    "CaseFieldID": "hubLinksStatuses",
     "UserRole": "caseworker-employment-legalrep-solicitor",
     "CRUD": "CRU"
   },
   {
     "CaseTypeId": "ET_Scotland",
-    "CaseFieldID": "hubLinks",
+    "CaseFieldID": "hubLinksStatuses",
     "UserRole": "caseworker-employment-etjudge",
     "CRUD": "R"
   },
   {
     "CaseTypeId": "ET_Scotland",
-    "CaseFieldID": "hubLinks",
+    "CaseFieldID": "hubLinksStatuses",
     "UserRole": "caseworker-employment-etjudge-scotland",
     "CRUD": "CRUD"
   },
   {
     "CaseTypeId": "ET_Scotland",
-    "CaseFieldID": "hubLinks",
+    "CaseFieldID": "hubLinksStatuses",
     "UserRole": "caseworker-employment-scotland",
     "CRUD": "CRUD"
   },
   {
     "CaseTypeId": "ET_Scotland",
-    "CaseFieldID": "hubLinks",
+    "CaseFieldID": "hubLinksStatuses",
     "UserRole": "caseworker-employment",
     "CRUD": "R"
   },
   {
     "CaseTypeId": "ET_Scotland",
-    "CaseFieldID": "hubLinks",
+    "CaseFieldID": "hubLinksStatuses",
     "UserRole": "caseworker-employment-api",
     "CRUD": "CRUD"
   },

--- a/definitions/json/CaseEventToFields.json
+++ b/definitions/json/CaseEventToFields.json
@@ -918,7 +918,7 @@
   {
     "CaseTypeID": "ET_Scotland",
     "CaseEventID": "UPDATE_CASE_SUBMITTED",
-    "CaseFieldID": "hubLinks",
+    "CaseFieldID": "hubLinksStatuses",
     "DisplayContext": "MANDATORY",
     "PageID": 1,
     "PageDisplayOrder": 1

--- a/definitions/json/CaseField.json
+++ b/definitions/json/CaseField.json
@@ -3439,9 +3439,9 @@
   },
   {
     "CaseTypeID": "ET_Scotland",
-    "ID": "hubLinks",
+    "ID": "hubLinksStatuses",
     "Label": " ",
-    "FieldType": "hubLinks",
+    "FieldType": "hubLinksStatuses",
     "SecurityClassification": "Public"
   },
   {

--- a/definitions/json/ComplexTypes.json
+++ b/definitions/json/ComplexTypes.json
@@ -5891,86 +5891,72 @@
     "SecurityClassification": "Public"
   },
   {
-    "ID": "hubLink",
-    "ListElementCode": "status",
-    "FieldType": "Text",
-    "ElementLabel": " ",
-    "SecurityClassification": "Public"
-  },
-  {
-    "ID": "hubLink",
-    "ListElementCode": "link",
-    "FieldType": "Text",
-    "ElementLabel": " ",
-    "SecurityClassification": "Public"
-  },
-  {
-    "ID": "hubLinks",
+    "ID": "hubLinksStatuses",
     "ListElementCode": "personalDetails",
-    "FieldType": "hubLink",
+    "FieldType": "Text",
     "ElementLabel": " ",
     "SecurityClassification": "Public"
   },
   {
-    "ID": "hubLinks",
+    "ID": "hubLinksStatuses",
     "ListElementCode": "et1ClaimForm",
-    "FieldType": "hubLink",
+    "FieldType": "Text",
     "ElementLabel": " ",
     "SecurityClassification": "Public"
   },
   {
-    "ID": "hubLinks",
+    "ID": "hubLinksStatuses",
     "ListElementCode": "respondentResponse",
-    "FieldType": "hubLink",
+    "FieldType": "Text",
     "ElementLabel": " ",
     "SecurityClassification": "Public"
   },
   {
-    "ID": "hubLinks",
+    "ID": "hubLinksStatuses",
     "ListElementCode": "hearingDetails",
-    "FieldType": "hubLink",
+    "FieldType": "Text",
     "ElementLabel": " ",
     "SecurityClassification": "Public"
   },
   {
-    "ID": "hubLinks",
+    "ID": "hubLinksStatuses",
     "ListElementCode": "requestsAndApplications",
-    "FieldType": "hubLink",
+    "FieldType": "Text",
     "ElementLabel": " ",
     "SecurityClassification": "Public"
   },
   {
-    "ID": "hubLinks",
+    "ID": "hubLinksStatuses",
     "ListElementCode": "respondentApplications",
-    "FieldType": "hubLink",
+    "FieldType": "Text",
     "ElementLabel": " ",
     "SecurityClassification": "Public"
   },
   {
-    "ID": "hubLinks",
+    "ID": "hubLinksStatuses",
     "ListElementCode": "contactTribunal",
-    "FieldType": "hubLink",
+    "FieldType": "Text",
     "ElementLabel": " ",
     "SecurityClassification": "Public"
   },
   {
-    "ID": "hubLinks",
+    "ID": "hubLinksStatuses",
     "ListElementCode": "tribunalOrders",
-    "FieldType": "hubLink",
+    "FieldType": "Text",
     "ElementLabel": " ",
     "SecurityClassification": "Public"
   },
   {
-    "ID": "hubLinks",
+    "ID": "hubLinksStatuses",
     "ListElementCode": "tribunalJudgements",
-    "FieldType": "hubLink",
+    "FieldType": "Text",
     "ElementLabel": " ",
     "SecurityClassification": "Public"
   },
   {
-    "ID": "hubLinks",
+    "ID": "hubLinksStatuses",
     "ListElementCode": "documents",
-    "FieldType": "hubLink",
+    "FieldType": "Text",
     "ElementLabel": " ",
     "SecurityClassification": "Public"
   }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RET-2530
Don't store links of hublinks, only their statuses.

Not backwards compatible but no one has used the links on the hublinks yet so it doesn't really break anything.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
