### PR TITLE
RET-2574: Add Unassigned option to fl_TribunalOffice

### DIFF
--- a/definitions/json/Scotland Scrubbed.json
+++ b/definitions/json/Scotland Scrubbed.json
@@ -4121,6 +4121,12 @@
     "DisplayOrder": 4
   },
   {
+    "ID": "fl_TribunalOffice",
+    "ListElementCode": "Unassigned",
+    "ListElement": "Unassigned",
+    "DisplayOrder": 5
+  },
+  {
     "ID": "fl_notice_period_unit",
     "ListElementCode": "Weeks",
     "ListElement": "Weeks",


### PR DESCRIPTION
JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/RET-2574

Change description
Logic to assign case to local office

If claimantWorkAddress postcode exists pass it to PostCodeToLocalOffice service.

Else if loop through respondents and if a postcode exists on the respondent address, pass it to PostCodeToLocalOffice service.

If neither exist, managing office will not be set and the callbacks will assign to a default office

Fallback logic for no managing office needs to be implemented as part of this ticket - https://tools.hmcts.net/jira/browse/RET-2730

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x ] No