### PR TITLE
RET-2843: Added missing authorisations and respondentId field in resp…

### DIFF
--- a/definitions/json/AuthorisationCaseEvent.json
+++ b/definitions/json/AuthorisationCaseEvent.json
@@ -1120,6 +1120,13 @@
   {
     "LiveFrom": "01/01/2017",
     "CaseTypeId": "ET_Scotland",
+    "CaseEventID": "updateRepresentation",
+    "UserRole": "caseworker-employment-api",
+    "CRUD": "CRUD"
+  },
+  {
+    "LiveFrom": "01/01/2017",
+    "CaseTypeId": "ET_Scotland",
     "CaseEventID": "applyNocDecision",
     "UserRole": "caseworker-approver",
     "CRUD": "CRUD"

--- a/definitions/json/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField.json
@@ -18613,6 +18613,12 @@
   },
   {
     "CaseTypeId": "ET_Scotland",
+    "CaseFieldID": "changeOrganisationRequestField",
+    "UserRole": "caseworker-employment-api",
+    "CRUD": "CRU"
+  },
+  {
+    "CaseTypeId": "ET_Scotland",
     "CaseFieldID": "etICHearingAlreadyListed",
     "UserRole": "citizen",
     "CRUD": "CRU"

--- a/definitions/json/CaseEvent.json
+++ b/definitions/json/CaseEvent.json
@@ -212,6 +212,7 @@
     "PostConditionState": "*",
     "CallBackURLAboutToStartEvent": "${ET_COS_URL}/dynamicRespondentRepresentativeNames",
     "CallBackURLAboutToSubmitEvent": "${ET_COS_URL}/amendRespondentRepresentative",
+    "CallBackURLSubmittedEvent": "${ET_COS_URL}/amendRespondentRepSubmitted",
     "SecurityClassification": "Public",
     "ShowEventNotes": "N"
   },

--- a/definitions/json/ComplexTypes.json
+++ b/definitions/json/ComplexTypes.json
@@ -1260,6 +1260,14 @@
   },
   {
     "ID": "RespondentRepresentative",
+    "ListElementCode": "respondentId",
+    "FieldType": "Text",
+    "ElementLabel": "Respondent Id",
+    "FieldShowCondition": "resp_rep_name=\"dummy\"",
+    "SecurityClassification": "Public"
+  },
+  {
+    "ID": "RespondentRepresentative",
     "ListElementCode": "dynamic_resp_rep_name",
     "FieldType": "DynamicList",
     "ElementLabel": "Respondent who is being represented",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-2843


### Change description ###
Added missing authorisations and respondentId field in respondent rep

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[  x ] No
```
