### PR TITLE
Scotland - linkedCaseCT label display fix

### DIFF
--- a/definitions/json/CaseTypeTab.json
+++ b/definitions/json/CaseTypeTab.json
@@ -224,7 +224,7 @@
     "TabID": "CaseOverview",
     "CaseFieldID": "linkedCaseCTLabel",
     "TabFieldDisplayOrder": 24,
-    "FieldShowCondition": "linkedCaseCT=\"*\""
+    "FieldShowCondition": "linkedCaseCT!=\"\""
   },
   {
     "CaseTypeID": "ET_Scotland",


### PR DESCRIPTION
The FieldShowCondition for linkedCaseCTLabel is set to linkedCaseCT!=“”. It used to be linkedCaseCT=“*”. Fix went in CaseTyepTab, row 29.


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
