### PR TITLE
Enabler for Release 2.1

### DIFF
--- a/definitions/json/AuthorisationCaseEvent.json
+++ b/definitions/json/AuthorisationCaseEvent.json
@@ -1571,6 +1571,12 @@
   },
   {
     "CaseTypeId": "ET_Scotland",
+    "CaseEventID": "UPDATE_APPLICATION_STATE",
+    "UserRole": "citizen",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_Scotland",
     "CaseEventID": "UPDATE_NOTIFICATION_RESPONSE",
     "UserRole": "citizen",
     "CRUD": "CRU"

--- a/definitions/json/CaseEvent.json
+++ b/definitions/json/CaseEvent.json
@@ -49,6 +49,22 @@
   },
   {
     "CaseTypeID": "ET_Scotland",
+    "ID": "UPDATE_APPLICATION_STATE",
+    "Name": "View an application",
+    "Description": "View an application",
+    "DisplayOrder": 44,
+    "PreConditionState(s)": "*",
+    "PostConditionState": "*",
+    "SecurityClassification": "Public",
+    "ShowEventNotes": "N",
+    "ShowSummary": "N",
+    "EventEnablingCondition": "caseType=\"dummy\"",
+    "CallBackURLAboutToStartEvent": "",
+    "CallBackURLAboutToSubmitEvent": "",
+    "CallBackURLSubmittedEvent": ""
+  },
+  {
+    "CaseTypeID": "ET_Scotland",
     "ID": "pseRespondentRespondToTribunal",
     "Name": "Respond to an Order or Request",
     "Description": "Respond to an Order or Request",


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
Update to prevent CLAIMANT_TSE_RESPOND being triggered twice when a Claimant sends a response

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
