### PR TITLE
Use case roles instead of IDAM roles

### DIFF
--- a/definitions/json/AuthorisationCaseField/AuthorisationCaseField.json
+++ b/definitions/json/AuthorisationCaseField/AuthorisationCaseField.json
@@ -2936,7 +2936,13 @@
   {
     "CaseTypeId": "ET_Scotland",
     "CaseFieldID": "documentCollection",
-    "UserRole": "citizen",
+    "UserRole": "[CREATOR]",
+    "CRUD": "CRUD"
+  },
+  {
+    "CaseTypeId": "ET_Scotland",
+    "CaseFieldID": "documentCollection",
+    "UserRole": "[DEFENDANT]",
     "CRUD": "CRUD"
   },
   {


### PR DESCRIPTION
Limit documentCollection access on citizens to the corresponding case roles as there are professional users with the citizen role which grants them access to docs they shouldn't see. Using case roles will correct this as they would not have the case role on the case