### PR TITLE
RET-5976

### DIFF
--- a/definitions/json/CaseEvent/CaseEvent-WA.json
+++ b/definitions/json/CaseEvent/CaseEvent-WA.json
@@ -288,7 +288,7 @@
   {
     "CaseTypeID": "ET_Scotland",
     "ID": "createReferral",
-    "Name": "Referral",
+    "Name": "Create Referral",
     "Description": "Referral",
     "DisplayOrder": 46,
     "PreConditionState(s)": "*",
@@ -305,7 +305,7 @@
   {
     "CaseTypeID": "ET_Scotland",
     "ID": "replyToReferral",
-    "Name": "Referral",
+    "Name": "Reply to Referral",
     "Description": "Refer to admin, legal officer or judge",
     "DisplayOrder": 48,
     "PreConditionState(s)": "*",
@@ -322,7 +322,7 @@
   {
     "CaseTypeID": "ET_Scotland",
     "ID": "closeReferral",
-    "Name": "Referral",
+    "Name": "Close Referral",
     "Description": "Close referral",
     "DisplayOrder": 49,
     "PreConditionState(s)": "*",


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RET-5976

Rename referral events as in case history, no way to identify what the events are
<img width="241" height="230" alt="Screenshot 2025-08-29 at 10 53 14" src="https://github.com/user-attachments/assets/9cfa3223-7a70-4f89-867f-5847e6d191d3" />
